### PR TITLE
Fix redundant end

### DIFF
--- a/app.js
+++ b/app.js
@@ -37,7 +37,6 @@ app.use('*', (req,res) => {
       cookies: req.cookies,
       params: req.params
     })
-    .end()
 })
 
 module.exports = app


### PR DESCRIPTION
## Summary
- remove redundant `.end()` call in catch-all route

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68400ac70f0883259d76784f330b4183